### PR TITLE
Add authentication screens: PhoneInputScreen, OtpVerificationScreen, …

### DIFF
--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -1,6 +1,10 @@
 // GetIt => class dependency injection (files depend on each other).
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get_it/get_it.dart';
 import 'package:magicchat/core/service/theme_service.dart';
+import 'package:magicchat/features/auth/data/repo/auth_repo.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_cubit.dart';
+import 'package:magicchat/features/home/data/repo/user_repo.dart';
 import 'package:magicchat/features/home/logic/cubit/home_cubit.dart';
 import 'package:magicchat/features/onboarding/logic/onboarding_cubit.dart';
 import 'package:magicchat/features/settings/logic/cubit/settings_cubit.dart';
@@ -8,10 +12,20 @@ import 'package:magicchat/features/settings/logic/cubit/settings_cubit.dart';
 final getIt = GetIt.instance;
 
 Future<void> setupGetIt() async {
+  getIt.registerLazySingleton<FirebaseFirestore>(
+      () => FirebaseFirestore.instance);
   getIt.registerFactory<OnboardingCubit>(() => OnboardingCubit());
 
-  getIt.registerFactory<HomeCubit>(() => HomeCubit());
+  getIt.registerLazySingleton<UserRepository>(
+      () => UserRepository(firestore: getIt<FirebaseFirestore>()));
+
+  getIt.registerFactory<HomeCubit>(() => HomeCubit(userRepository: getIt<UserRepository>() ));
 
   getIt.registerLazySingleton<ThemeService>(() => ThemeService());
   getIt.registerLazySingleton(() => SettingsCubit(getIt<ThemeService>()));
+
+  getIt.registerLazySingleton<AuthRepository>(
+      () => AuthRepository(firestore: getIt<FirebaseFirestore>()));
+  getIt.registerLazySingleton(
+      () => AuthCubit(authRepository: getIt<AuthRepository>()));
 }

--- a/lib/core/networking/operation_result.dart
+++ b/lib/core/networking/operation_result.dart
@@ -7,5 +7,3 @@ abstract class OperationResult<T> with _$OperationResult<T> {
   const factory OperationResult.failure(String error) = Failure<T>;
 }
  
- // This Class is used to represent the result of an operation. It can either be a success or a failure.
- // same api_result class but with a different name.

--- a/lib/core/resourses/assets_manager.dart
+++ b/lib/core/resourses/assets_manager.dart
@@ -10,7 +10,8 @@ class AssetsManager {
   static const String onboarding2Image = '$imagesPath/onboarding2.png';
   static const String onboarding3Image = '$imagesPath/onboarding3.png';
 
-
+  // icons
+  static const String appIcon = '$iconsPath/app_icon.png';
 
 
 }

--- a/lib/core/resourses/sizes_util_manager.dart
+++ b/lib/core/resourses/sizes_util_manager.dart
@@ -55,6 +55,7 @@ class WidthManager {
   static double w76 = SizeUtil.setWidth(76.0);
   static double w80 = SizeUtil.setWidth(80.0);
   static double w100 = SizeUtil.setWidth(100.0);
+  static double w140 = SizeUtil.setWidth(140.0);
   static double w812 = SizeUtil.setWidth(812.0);
 
 }
@@ -90,6 +91,7 @@ class HeightManager {
   static double h80 = SizeUtil.setHeight(80.0);
   static double h90 = SizeUtil.setHeight(90.0);
   static double h100 = SizeUtil.setHeight(100.0);
+  static double h140 = SizeUtil.setHeight(140.0);
   static double h375 = SizeUtil.setHeight(375.0);
 
 }

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -2,12 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:magicchat/core/routes/routes.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_cubit.dart';
+import 'package:magicchat/features/auth/ui/views/otp_verification_screen.dart';
+import 'package:magicchat/features/auth/ui/views/phone_input_screen.dart';
+import 'package:magicchat/features/auth/ui/views/username_setup_screen.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
 import 'package:magicchat/features/home/logic/cubit/home_cubit.dart';
 import 'package:magicchat/features/home/ui/views/home_screen.dart';
 import 'package:magicchat/features/onboarding/logic/onboarding_cubit.dart';
 import 'package:magicchat/features/onboarding/ui/views/onboarding_screen.dart';
 import 'package:magicchat/features/settings/logic/cubit/settings_cubit.dart';
 import 'package:magicchat/features/settings/ui/views/settings_screen.dart';
+
 final getIt = GetIt.instance;
 
 class AppRouter {
@@ -25,17 +31,61 @@ class AppRouter {
       case Routes.homeScreen:
         return MaterialPageRoute(
           builder: (_) => BlocProvider(
-            create: (_) => getIt<HomeCubit>(),
+            create: (_) => getIt<HomeCubit>()..checkUserLoginStatus(),
             child: const HomeScreen(),
           ),
         );
       case Routes.settingsScreen:
+        final args = arguments as Map?;
+        final isLoggedIn = args?['isLoggedIn'] as bool? ?? false;
+        final user = args?['user'] as UserModel?;
         return MaterialPageRoute(
-          builder: (context) => BlocProvider.value(
-            value: getIt<SettingsCubit>(),
-            child: const SettingsScreen(),
+          builder: (context) => MultiBlocProvider(
+            providers: [
+              BlocProvider.value(
+                value: getIt<SettingsCubit>(),
+              ),
+              BlocProvider.value(
+                value: getIt<AuthCubit>(), // توفّر AuthCubit هنا
+              ),
+            ],
+            child: SettingsScreen(
+              isLoggedIn: isLoggedIn,
+              user: user,
+            ),
           ),
         );
+
+      case Routes.phoneInputScreen:
+        return MaterialPageRoute(
+          builder: (_) => BlocProvider.value(
+            value: getIt<AuthCubit>(),
+            child: const PhoneInputScreen(),
+          ),
+        );
+      case Routes.otpVerificationScreen:
+        final arguments = settings.arguments as Map?;
+
+        final phoneNumber = arguments?['phoneNumber'] as String;
+        final sentOtpCode = arguments?['sentOtpCode'] as String;
+
+        return MaterialPageRoute(
+          builder: (_) => BlocProvider.value(
+            value: getIt<AuthCubit>(), // أو أي طريقة تحضر بها الـ Cubit عندك
+            child: OtpVerificationScreen(
+              phoneNumber: phoneNumber,
+              sentOtpCode: sentOtpCode,
+            ),
+          ),
+        );
+      case Routes.usernameSetupScreen:
+        return MaterialPageRoute(
+          builder: (_) => BlocProvider.value(
+            value: getIt<AuthCubit>(),
+            child: const UsernameSetupScreen(),
+          ),
+        );
+
       default:
         return null;
     }

--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -2,4 +2,7 @@ class Routes {
    static const String onboardingScreen = '/onboardingScreen';
    static const String homeScreen = '/homeScreen';
    static const String settingsScreen = '/settingsScreen';
+   static const String phoneInputScreen = '/phoneInputScreen';
+   static const String otpVerificationScreen = '/otpVerificationScreen';
+   static const String usernameSetupScreen = '/usernameSetupScreen';
 }

--- a/lib/features/auth/data/repo/auth_repo.dart
+++ b/lib/features/auth/data/repo/auth_repo.dart
@@ -1,0 +1,107 @@
+// 📁 auth_repository.dart
+import 'dart:convert';
+import 'dart:io';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:http/http.dart' as http;
+import 'package:magicchat/core/helpers/shared_pref_helper.dart';
+import 'package:magicchat/core/networking/operation_result.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
+
+class AuthRepository {
+  final FirebaseFirestore firestore;
+
+  AuthRepository({required this.firestore});
+
+  Future<UserModel?> getUserIfExists(String phoneNumber) async {
+    final doc = await firestore.collection("users").doc(phoneNumber).get();
+    if (!doc.exists) return null;
+    return UserModel.fromJson(doc.data()!);
+  }
+
+  Future<void> markUserAsLoggedIn(String phoneNumber) async {
+    await firestore.collection("users").doc(phoneNumber).update({
+      "isLoggedIn": true,
+    });
+  }
+
+  Future<OperationResult<UserModel>> saveUserToFirestore({
+    required String phoneNumber,
+    required String username,
+    required File? imageFile,
+  }) async {
+    try {
+      final doc = await firestore.collection("users").doc(phoneNumber).get();
+      if (doc.exists) {
+        return const OperationResult.failure("هذا الرقم مستخدم بالفعل.");
+      }
+
+      String imageUrl = 'https://cdn-icons-png.flaticon.com/512/149/149071.png';
+      if (imageFile != null) {
+        imageUrl = await uploadImageToCloudinary(imageFile.path);
+      }
+
+      final user = UserModel(
+        phone: phoneNumber,
+        username: username,
+        imageUrl: imageUrl,
+        isLoggedIn: true,
+      );
+
+      await firestore.collection("users").doc(phoneNumber).set(user.toJson());
+
+      await SharedPrefHelper.setData('user_phone', phoneNumber);
+
+      return OperationResult.success(user);
+    } catch (e) {
+      return OperationResult.failure("خطأ أثناء حفظ البيانات: $e");
+    }
+  }
+
+  Future<String> uploadImageToCloudinary(String imagePath) async {
+    final url =
+        Uri.parse('https://api.cloudinary.com/v1_1/dmhmhyigi/image/upload');
+
+    final uploadRequest = http.MultipartRequest('POST', url);
+    uploadRequest.fields['upload_preset'] = 'leuko_care';
+
+    final imageBytes = await File(imagePath).readAsBytes();
+    final imageFile = http.MultipartFile.fromBytes(
+      'file',
+      imageBytes,
+      filename: 'image.jpg',
+    );
+
+    uploadRequest.files.add(imageFile);
+
+    final response = await uploadRequest.send();
+    final responseData = await response.stream.toBytes();
+    final result = json.decode(String.fromCharCodes(responseData));
+
+    if (response.statusCode == 200) {
+      return result['secure_url'];
+    } else {
+      throw Exception(
+          'Error uploading image: ${result['error']['message'] ?? result['error']}');
+    }
+  }
+
+  Future<bool> checkIfUserLoggedIn() async {
+    final cachedPhone = await SharedPrefHelper.getString('user_phone');
+
+    final doc = await firestore.collection("users").doc(cachedPhone).get();
+    return doc.exists && doc.data()?['isLoggedIn'] == true;
+  }
+
+  Future<void> logout() async {
+    try {
+      final cachedPhone = await SharedPrefHelper.getString('user_phone');
+      print('Logging out user: $cachedPhone');
+      await firestore.collection("users").doc(cachedPhone).update({
+        "isLoggedIn": false,
+      });
+    } catch (e) {
+      print('Error updating Firestore: $e');
+      rethrow;
+    }
+  }
+}

--- a/lib/features/auth/logic/cubit/auth_cubit.dart
+++ b/lib/features/auth/logic/cubit/auth_cubit.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:magicchat/core/helpers/shared_pref_helper.dart';
+import 'package:magicchat/features/auth/data/repo/auth_repo.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_state.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
+
+class AuthCubit extends Cubit<AuthState> {
+  final AuthRepository authRepository;
+  String? _phoneNumber;
+  UserModel? _user;
+
+  AuthCubit({required this.authRepository}) : super(const AuthState.initial());
+
+  void setPhoneNumber(String number) {
+    _phoneNumber = number;
+  }
+
+  Future<void> sendOtp() async {
+    if (_phoneNumber == null) return;
+    emit(const AuthState.loading());
+
+    final existingUser = await authRepository.getUserIfExists(_phoneNumber!);
+
+    if (existingUser == null) {
+      emit(AuthState.otpSent(
+        phoneNumber: _phoneNumber!,
+        verificationId: '123456',
+        isNewUser: true,
+      ));
+    } else {
+      _user = existingUser;
+      if (existingUser.isLoggedIn) {
+        emit(AuthState.alreadyLoggedIn(user: existingUser));
+      } else {
+        emit(AuthState.otpSent(
+          phoneNumber: _phoneNumber!,
+          verificationId: '123456',
+          isNewUser: false,
+        ));
+      }
+    }
+  }
+
+  Future<void> verifyOtp(String otp) async {
+    if (otp == '123456') {
+      if (_phoneNumber == null) {
+        emit(const AuthState.authError(errorMessage: 'رقم الهاتف غير موجود'));
+        return;
+      }
+
+      if (_user != null && !_user!.isLoggedIn) {
+        await authRepository.markUserAsLoggedIn(_phoneNumber!);
+        await SharedPrefHelper.setData('user_phone', _phoneNumber!);
+        emit(AuthState.authenticated(user: _user!));
+        return;
+      }
+      debugPrint("New user detected, navigating to username setup.");
+
+      emit(const AuthState.awaitingProfileInfo());
+    } else {
+      emit(const AuthState.verificationFailed(errorMessage: "OTP غير صحيح"));
+    }
+  }
+
+  Future<void> completeSignup({
+    required String username,
+    required File? imageFile,
+  }) async {
+    if (_phoneNumber == null) {
+      emit(const AuthState.authError(errorMessage: 'رقم الهاتف غير محدد'));
+      return;
+    }
+
+    emit(const AuthState.loading());
+
+    final result = await authRepository.saveUserToFirestore(
+      phoneNumber: _phoneNumber!,
+      username: username,
+      imageFile: imageFile,
+    );
+
+    result.when(
+      success: (user) {
+        _user = user;
+        emit(AuthState.authenticated(user: user));
+      },
+      failure: (failure) => emit(AuthState.authError(errorMessage: failure)),
+    );
+  }
+
+  Future<void> logout() async {
+    await authRepository.logout();
+    _phoneNumber = null;
+    _user = null;
+    await SharedPrefHelper.removeData('user_phone');
+    emit(const AuthState.unauthenticated());
+  }
+}

--- a/lib/features/auth/logic/cubit/auth_state.dart
+++ b/lib/features/auth/logic/cubit/auth_state.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
+
+part 'auth_state.freezed.dart';
+
+@freezed
+class AuthState with _$AuthState {
+  const factory AuthState.initial() = _Initial;
+
+  const factory AuthState.loading() = AuthLoading;
+
+  const factory AuthState.otpSent({
+    required String phoneNumber,
+    required String verificationId,
+    required bool isNewUser,
+  }) = OtpSent;
+
+  const factory AuthState.verificationFailed({
+    required String errorMessage,
+  }) = VerificationFailed;
+
+  const factory AuthState.awaitingProfileInfo() = AwaitingProfileInfo;
+
+  const factory AuthState.alreadyLoggedIn({required UserModel user}) = AlreadyLoggedIn;
+
+  const factory AuthState.authenticated({required UserModel user}) = Authenticated;
+
+  const factory AuthState.unauthenticated() = Unauthenticated;
+
+  const factory AuthState.authError({
+    required String errorMessage,
+  }) = AuthError;
+}

--- a/lib/features/auth/logic/cubit/auth_state.freezed.dart
+++ b/lib/features/auth/logic/cubit/auth_state.freezed.dart
@@ -1,0 +1,1704 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'auth_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$AuthState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AuthStateCopyWith<$Res> {
+  factory $AuthStateCopyWith(AuthState value, $Res Function(AuthState) then) =
+      _$AuthStateCopyWithImpl<$Res, AuthState>;
+}
+
+/// @nodoc
+class _$AuthStateCopyWithImpl<$Res, $Val extends AuthState>
+    implements $AuthStateCopyWith<$Res> {
+  _$AuthStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$InitialImplCopyWith<$Res> {
+  factory _$$InitialImplCopyWith(
+          _$InitialImpl value, $Res Function(_$InitialImpl) then) =
+      __$$InitialImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitialImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$InitialImpl>
+    implements _$$InitialImplCopyWith<$Res> {
+  __$$InitialImplCopyWithImpl(
+      _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$InitialImpl implements _Initial {
+  const _$InitialImpl();
+
+  @override
+  String toString() {
+    return 'AuthState.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitialImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial implements AuthState {
+  const factory _Initial() = _$InitialImpl;
+}
+
+/// @nodoc
+abstract class _$$AuthLoadingImplCopyWith<$Res> {
+  factory _$$AuthLoadingImplCopyWith(
+          _$AuthLoadingImpl value, $Res Function(_$AuthLoadingImpl) then) =
+      __$$AuthLoadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$AuthLoadingImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$AuthLoadingImpl>
+    implements _$$AuthLoadingImplCopyWith<$Res> {
+  __$$AuthLoadingImplCopyWithImpl(
+      _$AuthLoadingImpl _value, $Res Function(_$AuthLoadingImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$AuthLoadingImpl implements AuthLoading {
+  const _$AuthLoadingImpl();
+
+  @override
+  String toString() {
+    return 'AuthState.loading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$AuthLoadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class AuthLoading implements AuthState {
+  const factory AuthLoading() = _$AuthLoadingImpl;
+}
+
+/// @nodoc
+abstract class _$$OtpSentImplCopyWith<$Res> {
+  factory _$$OtpSentImplCopyWith(
+          _$OtpSentImpl value, $Res Function(_$OtpSentImpl) then) =
+      __$$OtpSentImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String phoneNumber, String verificationId, bool isNewUser});
+}
+
+/// @nodoc
+class __$$OtpSentImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$OtpSentImpl>
+    implements _$$OtpSentImplCopyWith<$Res> {
+  __$$OtpSentImplCopyWithImpl(
+      _$OtpSentImpl _value, $Res Function(_$OtpSentImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? phoneNumber = null,
+    Object? verificationId = null,
+    Object? isNewUser = null,
+  }) {
+    return _then(_$OtpSentImpl(
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      verificationId: null == verificationId
+          ? _value.verificationId
+          : verificationId // ignore: cast_nullable_to_non_nullable
+              as String,
+      isNewUser: null == isNewUser
+          ? _value.isNewUser
+          : isNewUser // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$OtpSentImpl implements OtpSent {
+  const _$OtpSentImpl(
+      {required this.phoneNumber,
+      required this.verificationId,
+      required this.isNewUser});
+
+  @override
+  final String phoneNumber;
+  @override
+  final String verificationId;
+  @override
+  final bool isNewUser;
+
+  @override
+  String toString() {
+    return 'AuthState.otpSent(phoneNumber: $phoneNumber, verificationId: $verificationId, isNewUser: $isNewUser)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OtpSentImpl &&
+            (identical(other.phoneNumber, phoneNumber) ||
+                other.phoneNumber == phoneNumber) &&
+            (identical(other.verificationId, verificationId) ||
+                other.verificationId == verificationId) &&
+            (identical(other.isNewUser, isNewUser) ||
+                other.isNewUser == isNewUser));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, phoneNumber, verificationId, isNewUser);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OtpSentImplCopyWith<_$OtpSentImpl> get copyWith =>
+      __$$OtpSentImplCopyWithImpl<_$OtpSentImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return otpSent(phoneNumber, verificationId, isNewUser);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return otpSent?.call(phoneNumber, verificationId, isNewUser);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (otpSent != null) {
+      return otpSent(phoneNumber, verificationId, isNewUser);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return otpSent(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return otpSent?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (otpSent != null) {
+      return otpSent(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class OtpSent implements AuthState {
+  const factory OtpSent(
+      {required final String phoneNumber,
+      required final String verificationId,
+      required final bool isNewUser}) = _$OtpSentImpl;
+
+  String get phoneNumber;
+  String get verificationId;
+  bool get isNewUser;
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$OtpSentImplCopyWith<_$OtpSentImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VerificationFailedImplCopyWith<$Res> {
+  factory _$$VerificationFailedImplCopyWith(_$VerificationFailedImpl value,
+          $Res Function(_$VerificationFailedImpl) then) =
+      __$$VerificationFailedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String errorMessage});
+}
+
+/// @nodoc
+class __$$VerificationFailedImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$VerificationFailedImpl>
+    implements _$$VerificationFailedImplCopyWith<$Res> {
+  __$$VerificationFailedImplCopyWithImpl(_$VerificationFailedImpl _value,
+      $Res Function(_$VerificationFailedImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? errorMessage = null,
+  }) {
+    return _then(_$VerificationFailedImpl(
+      errorMessage: null == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VerificationFailedImpl implements VerificationFailed {
+  const _$VerificationFailedImpl({required this.errorMessage});
+
+  @override
+  final String errorMessage;
+
+  @override
+  String toString() {
+    return 'AuthState.verificationFailed(errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VerificationFailedImpl &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, errorMessage);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VerificationFailedImplCopyWith<_$VerificationFailedImpl> get copyWith =>
+      __$$VerificationFailedImplCopyWithImpl<_$VerificationFailedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return verificationFailed(errorMessage);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return verificationFailed?.call(errorMessage);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (verificationFailed != null) {
+      return verificationFailed(errorMessage);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return verificationFailed(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return verificationFailed?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (verificationFailed != null) {
+      return verificationFailed(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VerificationFailed implements AuthState {
+  const factory VerificationFailed({required final String errorMessage}) =
+      _$VerificationFailedImpl;
+
+  String get errorMessage;
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VerificationFailedImplCopyWith<_$VerificationFailedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$AwaitingProfileInfoImplCopyWith<$Res> {
+  factory _$$AwaitingProfileInfoImplCopyWith(_$AwaitingProfileInfoImpl value,
+          $Res Function(_$AwaitingProfileInfoImpl) then) =
+      __$$AwaitingProfileInfoImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$AwaitingProfileInfoImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$AwaitingProfileInfoImpl>
+    implements _$$AwaitingProfileInfoImplCopyWith<$Res> {
+  __$$AwaitingProfileInfoImplCopyWithImpl(_$AwaitingProfileInfoImpl _value,
+      $Res Function(_$AwaitingProfileInfoImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$AwaitingProfileInfoImpl implements AwaitingProfileInfo {
+  const _$AwaitingProfileInfoImpl();
+
+  @override
+  String toString() {
+    return 'AuthState.awaitingProfileInfo()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AwaitingProfileInfoImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return awaitingProfileInfo();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return awaitingProfileInfo?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (awaitingProfileInfo != null) {
+      return awaitingProfileInfo();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return awaitingProfileInfo(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return awaitingProfileInfo?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (awaitingProfileInfo != null) {
+      return awaitingProfileInfo(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class AwaitingProfileInfo implements AuthState {
+  const factory AwaitingProfileInfo() = _$AwaitingProfileInfoImpl;
+}
+
+/// @nodoc
+abstract class _$$AlreadyLoggedInImplCopyWith<$Res> {
+  factory _$$AlreadyLoggedInImplCopyWith(_$AlreadyLoggedInImpl value,
+          $Res Function(_$AlreadyLoggedInImpl) then) =
+      __$$AlreadyLoggedInImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({UserModel user});
+}
+
+/// @nodoc
+class __$$AlreadyLoggedInImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$AlreadyLoggedInImpl>
+    implements _$$AlreadyLoggedInImplCopyWith<$Res> {
+  __$$AlreadyLoggedInImplCopyWithImpl(
+      _$AlreadyLoggedInImpl _value, $Res Function(_$AlreadyLoggedInImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? user = null,
+  }) {
+    return _then(_$AlreadyLoggedInImpl(
+      user: null == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as UserModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$AlreadyLoggedInImpl implements AlreadyLoggedIn {
+  const _$AlreadyLoggedInImpl({required this.user});
+
+  @override
+  final UserModel user;
+
+  @override
+  String toString() {
+    return 'AuthState.alreadyLoggedIn(user: $user)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AlreadyLoggedInImpl &&
+            (identical(other.user, user) || other.user == user));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, user);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AlreadyLoggedInImplCopyWith<_$AlreadyLoggedInImpl> get copyWith =>
+      __$$AlreadyLoggedInImplCopyWithImpl<_$AlreadyLoggedInImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return alreadyLoggedIn(user);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return alreadyLoggedIn?.call(user);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (alreadyLoggedIn != null) {
+      return alreadyLoggedIn(user);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return alreadyLoggedIn(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return alreadyLoggedIn?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (alreadyLoggedIn != null) {
+      return alreadyLoggedIn(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class AlreadyLoggedIn implements AuthState {
+  const factory AlreadyLoggedIn({required final UserModel user}) =
+      _$AlreadyLoggedInImpl;
+
+  UserModel get user;
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AlreadyLoggedInImplCopyWith<_$AlreadyLoggedInImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$AuthenticatedImplCopyWith<$Res> {
+  factory _$$AuthenticatedImplCopyWith(
+          _$AuthenticatedImpl value, $Res Function(_$AuthenticatedImpl) then) =
+      __$$AuthenticatedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({UserModel user});
+}
+
+/// @nodoc
+class __$$AuthenticatedImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$AuthenticatedImpl>
+    implements _$$AuthenticatedImplCopyWith<$Res> {
+  __$$AuthenticatedImplCopyWithImpl(
+      _$AuthenticatedImpl _value, $Res Function(_$AuthenticatedImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? user = null,
+  }) {
+    return _then(_$AuthenticatedImpl(
+      user: null == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as UserModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$AuthenticatedImpl implements Authenticated {
+  const _$AuthenticatedImpl({required this.user});
+
+  @override
+  final UserModel user;
+
+  @override
+  String toString() {
+    return 'AuthState.authenticated(user: $user)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AuthenticatedImpl &&
+            (identical(other.user, user) || other.user == user));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, user);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AuthenticatedImplCopyWith<_$AuthenticatedImpl> get copyWith =>
+      __$$AuthenticatedImplCopyWithImpl<_$AuthenticatedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return authenticated(user);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return authenticated?.call(user);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (authenticated != null) {
+      return authenticated(user);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return authenticated(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return authenticated?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (authenticated != null) {
+      return authenticated(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Authenticated implements AuthState {
+  const factory Authenticated({required final UserModel user}) =
+      _$AuthenticatedImpl;
+
+  UserModel get user;
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AuthenticatedImplCopyWith<_$AuthenticatedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$UnauthenticatedImplCopyWith<$Res> {
+  factory _$$UnauthenticatedImplCopyWith(_$UnauthenticatedImpl value,
+          $Res Function(_$UnauthenticatedImpl) then) =
+      __$$UnauthenticatedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$UnauthenticatedImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$UnauthenticatedImpl>
+    implements _$$UnauthenticatedImplCopyWith<$Res> {
+  __$$UnauthenticatedImplCopyWithImpl(
+      _$UnauthenticatedImpl _value, $Res Function(_$UnauthenticatedImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$UnauthenticatedImpl implements Unauthenticated {
+  const _$UnauthenticatedImpl();
+
+  @override
+  String toString() {
+    return 'AuthState.unauthenticated()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$UnauthenticatedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return unauthenticated();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return unauthenticated?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (unauthenticated != null) {
+      return unauthenticated();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return unauthenticated(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return unauthenticated?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (unauthenticated != null) {
+      return unauthenticated(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Unauthenticated implements AuthState {
+  const factory Unauthenticated() = _$UnauthenticatedImpl;
+}
+
+/// @nodoc
+abstract class _$$AuthErrorImplCopyWith<$Res> {
+  factory _$$AuthErrorImplCopyWith(
+          _$AuthErrorImpl value, $Res Function(_$AuthErrorImpl) then) =
+      __$$AuthErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String errorMessage});
+}
+
+/// @nodoc
+class __$$AuthErrorImplCopyWithImpl<$Res>
+    extends _$AuthStateCopyWithImpl<$Res, _$AuthErrorImpl>
+    implements _$$AuthErrorImplCopyWith<$Res> {
+  __$$AuthErrorImplCopyWithImpl(
+      _$AuthErrorImpl _value, $Res Function(_$AuthErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? errorMessage = null,
+  }) {
+    return _then(_$AuthErrorImpl(
+      errorMessage: null == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$AuthErrorImpl implements AuthError {
+  const _$AuthErrorImpl({required this.errorMessage});
+
+  @override
+  final String errorMessage;
+
+  @override
+  String toString() {
+    return 'AuthState.authError(errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AuthErrorImpl &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, errorMessage);
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AuthErrorImplCopyWith<_$AuthErrorImpl> get copyWith =>
+      __$$AuthErrorImplCopyWithImpl<_$AuthErrorImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+            String phoneNumber, String verificationId, bool isNewUser)
+        otpSent,
+    required TResult Function(String errorMessage) verificationFailed,
+    required TResult Function() awaitingProfileInfo,
+    required TResult Function(UserModel user) alreadyLoggedIn,
+    required TResult Function(UserModel user) authenticated,
+    required TResult Function() unauthenticated,
+    required TResult Function(String errorMessage) authError,
+  }) {
+    return authError(errorMessage);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+            String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult? Function(String errorMessage)? verificationFailed,
+    TResult? Function()? awaitingProfileInfo,
+    TResult? Function(UserModel user)? alreadyLoggedIn,
+    TResult? Function(UserModel user)? authenticated,
+    TResult? Function()? unauthenticated,
+    TResult? Function(String errorMessage)? authError,
+  }) {
+    return authError?.call(errorMessage);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String phoneNumber, String verificationId, bool isNewUser)?
+        otpSent,
+    TResult Function(String errorMessage)? verificationFailed,
+    TResult Function()? awaitingProfileInfo,
+    TResult Function(UserModel user)? alreadyLoggedIn,
+    TResult Function(UserModel user)? authenticated,
+    TResult Function()? unauthenticated,
+    TResult Function(String errorMessage)? authError,
+    required TResult orElse(),
+  }) {
+    if (authError != null) {
+      return authError(errorMessage);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(AuthLoading value) loading,
+    required TResult Function(OtpSent value) otpSent,
+    required TResult Function(VerificationFailed value) verificationFailed,
+    required TResult Function(AwaitingProfileInfo value) awaitingProfileInfo,
+    required TResult Function(AlreadyLoggedIn value) alreadyLoggedIn,
+    required TResult Function(Authenticated value) authenticated,
+    required TResult Function(Unauthenticated value) unauthenticated,
+    required TResult Function(AuthError value) authError,
+  }) {
+    return authError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(AuthLoading value)? loading,
+    TResult? Function(OtpSent value)? otpSent,
+    TResult? Function(VerificationFailed value)? verificationFailed,
+    TResult? Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult? Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult? Function(Authenticated value)? authenticated,
+    TResult? Function(Unauthenticated value)? unauthenticated,
+    TResult? Function(AuthError value)? authError,
+  }) {
+    return authError?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(AuthLoading value)? loading,
+    TResult Function(OtpSent value)? otpSent,
+    TResult Function(VerificationFailed value)? verificationFailed,
+    TResult Function(AwaitingProfileInfo value)? awaitingProfileInfo,
+    TResult Function(AlreadyLoggedIn value)? alreadyLoggedIn,
+    TResult Function(Authenticated value)? authenticated,
+    TResult Function(Unauthenticated value)? unauthenticated,
+    TResult Function(AuthError value)? authError,
+    required TResult orElse(),
+  }) {
+    if (authError != null) {
+      return authError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class AuthError implements AuthState {
+  const factory AuthError({required final String errorMessage}) =
+      _$AuthErrorImpl;
+
+  String get errorMessage;
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AuthErrorImplCopyWith<_$AuthErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/auth/ui/views/otp_verification_screen.dart
+++ b/lib/features/auth/ui/views/otp_verification_screen.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:magicchat/core/helpers/extensions.dart';
+import 'package:magicchat/core/resourses/assets_manager.dart';
+import 'package:magicchat/core/resourses/fonts_manager.dart';
+import 'package:magicchat/core/resourses/sizes_util_manager.dart';
+import 'package:magicchat/core/resourses/styles_manager.dart';
+import 'package:magicchat/core/routes/routes.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_cubit.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_state.dart';
+import 'package:pin_code_fields/pin_code_fields.dart';
+
+class OtpVerificationScreen extends StatelessWidget {
+  final String phoneNumber;
+  final String sentOtpCode;
+
+  const OtpVerificationScreen({
+    super.key,
+    required this.phoneNumber,
+    required this.sentOtpCode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Verify OTP')),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: EdgeInsets.symmetric(horizontal: WidthManager.w20),
+          child: BlocConsumer<AuthCubit, AuthState>(
+            listener: (context, state) {
+              state.maybeWhen(
+                authenticated: (user) {
+                  if (user.username.isNotEmpty) {
+                    context.pushReplacementNamed(Routes.homeScreen);
+                  } else {
+                    context.pushReplacementNamed(Routes.usernameSetupScreen);
+                  }
+                },
+                awaitingProfileInfo: () {
+                  context.pushReplacementNamed(Routes.usernameSetupScreen);
+                },
+                authError: (errorMessage) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(errorMessage),
+                      backgroundColor: Colors.redAccent,
+                    ),
+                  );
+                },
+                verificationFailed: (errorMessage) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(errorMessage),
+                      backgroundColor: Colors.redAccent,
+                    ),
+                  );
+                },
+                orElse: () {},
+              );
+            },
+            builder: (context, state) {
+              if (state is AuthLoading) {
+                return const Center(child: CircularProgressIndicator());
+              }
+
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Image.asset(
+                    AssetsManager.appIcon,
+                    height: HeightManager.h140,
+                    width: WidthManager.w140,
+                  ),
+                  SizedBox(height: HeightManager.h24),
+                  Text(
+                    'Welcome to MagicChat',
+                    style: getBoldTextStyle(
+                      fontSize: FontSizeManager.s16,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                  SizedBox(height: HeightManager.h8),
+                  Text(
+                    'Enter the OTP sent to your number',
+                    style: getMediumTextStyle(
+                      fontSize: FontSizeManager.s14,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  SizedBox(height: HeightManager.h30),
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceVariant,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(Icons.message, color: Colors.deepPurple),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            'Your verification code is: $sentOtpCode',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: Colors.deepPurple.shade700,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  SizedBox(height: HeightManager.h20),
+                  Text(
+                    phoneNumber,
+                    style: getBoldTextStyle(
+                      fontSize: FontSizeManager.s16,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                  SizedBox(height: HeightManager.h20),
+                  PinCodeTextField(
+                    appContext: context,
+                    length: 6,
+                    keyboardType: TextInputType.number,
+                    animationType: AnimationType.fade,
+                    autoFocus: true,
+                    cursorColor: theme.colorScheme.primary,
+                    pinTheme: PinTheme(
+                      shape: PinCodeFieldShape.box,
+                      borderRadius: BorderRadius.circular(12),
+                      fieldHeight: 50,
+                      fieldWidth: 45,
+                      activeFillColor: Colors.white,
+                      inactiveColor: Colors.grey,
+                      selectedColor: theme.colorScheme.primary,
+                    ),
+                    onChanged: (_) {},
+                    onCompleted: (value) {
+                      if (value.trim() != sentOtpCode) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Incorrect OTP code'),
+                            backgroundColor: Colors.redAccent,
+                          ),
+                        );
+                        return;
+                      }
+
+                      print('Submitting OTP: $value');
+                      context.read<AuthCubit>().verifyOtp(value);
+                    },
+                  ),
+                  SizedBox(height: HeightManager.h30),
+                  const Text(
+                    "Code will be verified automatically after entry.",
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/ui/views/phone_input_screen.dart
+++ b/lib/features/auth/ui/views/phone_input_screen.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl_phone_field/intl_phone_field.dart';
+import 'package:magicchat/core/helpers/extensions.dart';
+import 'package:magicchat/core/resourses/assets_manager.dart';
+import 'package:magicchat/core/resourses/fonts_manager.dart';
+import 'package:magicchat/core/resourses/sizes_util_manager.dart';
+import 'package:magicchat/core/resourses/styles_manager.dart';
+import 'package:magicchat/core/routes/routes.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_cubit.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_state.dart';
+
+class PhoneInputScreen extends StatefulWidget {
+  const PhoneInputScreen({super.key});
+
+  @override
+  State<PhoneInputScreen> createState() => _PhoneInputScreenState();
+}
+
+class _PhoneInputScreenState extends State<PhoneInputScreen> {
+  final _formKey = GlobalKey<FormState>();
+  bool _autoValidate = false;
+  String countryCode = '+970'; // افتراضي فلسطين
+  String phoneNumber = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login Screen')),
+      body: BlocListener<AuthCubit, AuthState>(
+        listener: (context, state) {
+          if (state is OtpSent) {
+            Navigator.of(context).pushNamed(
+              Routes.otpVerificationScreen,
+              arguments: {
+                'phoneNumber': state.phoneNumber,
+                'sentOtpCode': state.verificationId,
+              },
+            );
+          } else if (state is AlreadyLoggedIn) {
+            showDialog(
+              context: context,
+              builder: (_) => AlertDialog(
+                title: const Text('رقم مستخدم بالفعل'),
+                content: const Text(
+                    'هذا الرقم مرتبط بحساب نشط، يرجى تسجيل الخروج أولاً.'),
+                actions: [
+                  TextButton(
+                    onPressed: () {
+                      context.pop();
+                      context.pop();
+                      context.pop();
+                    },
+                    child: const Text('حسناً'),
+                  ),
+                ],
+              ),
+            );
+          }
+        },
+        child: Center(
+          child: SingleChildScrollView(
+            padding: EdgeInsets.symmetric(horizontal: WidthManager.w20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Image.asset(
+                  AssetsManager.appIcon,
+                  height: HeightManager.h140,
+                  width: WidthManager.w140,
+                ),
+                SizedBox(height: HeightManager.h24),
+                Text(
+                  'Welcome to MagicChat',
+                  style: getBoldTextStyle(
+                    fontSize: FontSizeManager.s16,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                SizedBox(height: HeightManager.h8),
+                Text(
+                  'Enter your phone number to continue',
+                  style: getMediumTextStyle(
+                    fontSize: FontSizeManager.s14,
+                    color: theme.colorScheme.onSurface,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                SizedBox(height: HeightManager.h30),
+                Form(
+                  key: _formKey,
+                  autovalidateMode: _autoValidate
+                      ? AutovalidateMode.always
+                      : AutovalidateMode.disabled,
+                  child: IntlPhoneField(
+                    initialCountryCode: 'PS',
+                    decoration: const InputDecoration(
+                      labelText: 'Phone Number',
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: (phone) {
+                      setState(() {
+                        countryCode = phone.countryCode;
+                        phoneNumber = phone.number.trim();
+                      });
+                    },
+                    validator: (phone) {
+                      if (phone == null || phone.number.trim().isEmpty) {
+                        return 'Please enter your phone number';
+                      }
+                      return null;
+                    },
+                  ),
+                ),
+                SizedBox(height: HeightManager.h30),
+                SizedBox(
+                  width: double.infinity,
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      final isValid = _formKey.currentState!.validate();
+                      if (!isValid) {
+                        setState(() {
+                          _autoValidate = true;
+                        });
+                        return;
+                      }
+
+                      final fullPhoneNumber = '$countryCode$phoneNumber';
+                      final authCubit = context.read<AuthCubit>();
+                      authCubit.setPhoneNumber(fullPhoneNumber);
+                      authCubit.sendOtp();
+                    },
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    child: Text(
+                      'Send OTP',
+                      style: TextStyle(
+                        fontSize: FontSizeManager.s18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(height: HeightManager.h20),
+                BlocBuilder<AuthCubit, AuthState>(
+                  builder: (context, state) {
+                    return state.maybeWhen(
+                      loading: () => const CircularProgressIndicator(),
+                      authError: (message) => Text(
+                        message,
+                        style: const TextStyle(color: Colors.red),
+                      ),
+                      orElse: () => const SizedBox.shrink(),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/ui/views/username_setup_screen.dart
+++ b/lib/features/auth/ui/views/username_setup_screen.dart
@@ -1,0 +1,184 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:magicchat/core/resourses/fonts_manager.dart';
+import 'package:magicchat/core/resourses/sizes_util_manager.dart';
+import 'package:magicchat/core/resourses/styles_manager.dart';
+import 'package:magicchat/core/routes/routes.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_cubit.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_state.dart';
+
+class UsernameSetupScreen extends StatefulWidget {
+  const UsernameSetupScreen({super.key});
+
+  @override
+  State<UsernameSetupScreen> createState() => _UsernameSetupScreenState();
+}
+
+class _UsernameSetupScreenState extends State<UsernameSetupScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
+  File? _selectedImage;
+  bool _autoValidate = false;
+
+  @override
+void dispose() {
+  _usernameController.dispose();
+  super.dispose();
+}
+
+  Future<void> _pickImage() async {
+    final picked = await ImagePicker().pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _selectedImage = File(picked.path);
+      });
+    }
+  }
+
+  void _submit() {
+    final isValid = _formKey.currentState!.validate();
+    if (!isValid) {
+      setState(() {
+        _autoValidate = true;
+      });
+      return;
+    }
+
+    final username = _usernameController.text.trim();
+    context.read<AuthCubit>().completeSignup(
+          username: username,
+          imageFile: _selectedImage,
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Set Up Profile')),
+      body: BlocConsumer<AuthCubit, AuthState>(
+        listener: (context, state) {
+          state.maybeWhen(
+            authenticated: (_) {
+              // الانتقال للشاشة الرئيسية أو شاشة الدردشة بعد نجاح التسجيل
+              Navigator.of(context).pushReplacementNamed(Routes.homeScreen);
+            },
+            authError: (message) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(message), backgroundColor: Colors.red),
+              );
+            },
+            orElse: () {},
+          );
+        },
+        builder: (context, state) {
+          if (state is AuthLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          return Center(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.symmetric(horizontal: WidthManager.w20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  GestureDetector(
+                    onTap: _pickImage,
+                    child: CircleAvatar(
+                      radius: HeightManager.h60,
+                      backgroundColor: Colors.deepPurple.shade50,
+                      backgroundImage:
+                          _selectedImage != null ? FileImage(_selectedImage!) : null,
+                      child: _selectedImage == null
+                          ? Icon(Icons.camera_alt, size: 40, color: Colors.deepPurple)
+                          : null,
+                    ),
+                  ),
+                  SizedBox(height: HeightManager.h16),
+                  Text(
+                    'Choose a profile picture (optional)',
+                    style: getMediumTextStyle(
+                      fontSize: FontSizeManager.s14,
+                      color: theme.colorScheme.onSurface.withOpacity(0.7),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  SizedBox(height: HeightManager.h30),
+                  Text(
+                    'Set a username',
+                    style: getBoldTextStyle(
+                      fontSize: FontSizeManager.s16,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                  SizedBox(height: HeightManager.h8),
+                  Text(
+                    'This name will be visible to other users',
+                    style: getMediumTextStyle(
+                      fontSize: FontSizeManager.s14,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  SizedBox(height: HeightManager.h30),
+                  Form(
+                    key: _formKey,
+                    autovalidateMode: _autoValidate
+                        ? AutovalidateMode.always
+                        : AutovalidateMode.disabled,
+                    child: TextFormField(
+                      controller: _usernameController,
+                      decoration: InputDecoration(
+                        labelText: 'Username',
+                        prefixIcon: const Icon(Icons.person),
+                        filled: true,
+                        fillColor: Colors.white,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'Please enter a username';
+                        }
+                        if (value.trim().length < 3) {
+                          return 'Username must be at least 3 characters';
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                  SizedBox(height: HeightManager.h30),
+                  SizedBox(
+                    width: double.infinity,
+                    height: 50,
+                    child: ElevatedButton(
+                      onPressed: _submit,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: theme.primaryColor,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: Text(
+                        'Finish Setup',
+                        style: getBoldTextStyle(
+                          fontSize: FontSizeManager.s18,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: HeightManager.h20),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/friends/ui/views/friends_screen.dart
+++ b/lib/features/friends/ui/views/friends_screen.dart
@@ -1,17 +1,30 @@
 import 'package:flutter/material.dart';
-
+import 'package:magicchat/core/helpers/extensions.dart';
+import 'package:magicchat/core/routes/routes.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
 class FriendsScreen extends StatelessWidget {
-  const FriendsScreen({super.key});
+  final bool isLoggedIn;
+  final UserModel? user;
+
+  const FriendsScreen({
+    super.key,
+    required this.isLoggedIn,
+    required this.user,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: Text(
-          'Friends List',
+        child: Column(
+          children: [
+            Text('Logged in: $isLoggedIn, Name: ${user?.username ?? "Guest"}'),
+             ElevatedButton(onPressed: (){
+              context.pushNamed(Routes.phoneInputScreen);
+            }, child: Text( 'Login'))
+          ],
         ),
       ),
-      
     );
   }
 }

--- a/lib/features/home/data/model/user_model.dart
+++ b/lib/features/home/data/model/user_model.dart
@@ -1,0 +1,37 @@
+
+import 'package:json_annotation/json_annotation.dart';
+part 'user_model.g.dart';
+
+@JsonSerializable()
+class UserModel {
+  final String phone;
+  final String username;
+  final bool isLoggedIn;
+  final String? imageUrl;
+  
+
+  UserModel({
+    required this.phone,
+    required this.username,
+    this.isLoggedIn = false,
+    this.imageUrl,
+  });
+
+  factory UserModel.fromJson(Map<String, dynamic> json) =>
+      _$UserModelFromJson(json);
+  Map<String, dynamic> toJson() => _$UserModelToJson(this);
+
+  UserModel copyWith({
+    String? phone,
+    String? username,
+    bool? isLoggedIn,
+    String? imageUrl,
+  }) {
+    return UserModel(
+      phone: phone ?? this.phone,
+      username: username ?? this.username,
+      isLoggedIn: isLoggedIn ?? this.isLoggedIn,
+      imageUrl: imageUrl ?? this.imageUrl,
+    );
+  }
+}

--- a/lib/features/home/data/model/user_model.g.dart
+++ b/lib/features/home/data/model/user_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+UserModel _$UserModelFromJson(Map<String, dynamic> json) => UserModel(
+      phone: json['phone'] as String,
+      username: json['username'] as String,
+      isLoggedIn: json['isLoggedIn'] as bool? ?? false,
+      imageUrl: json['imageUrl'] as String?,
+    );
+
+Map<String, dynamic> _$UserModelToJson(UserModel instance) => <String, dynamic>{
+      'phone': instance.phone,
+      'username': instance.username,
+      'isLoggedIn': instance.isLoggedIn,
+      'imageUrl': instance.imageUrl,
+    };

--- a/lib/features/home/data/repo/user_repo.dart
+++ b/lib/features/home/data/repo/user_repo.dart
@@ -1,0 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
+
+class UserRepository {
+  final FirebaseFirestore firestore;
+
+  UserRepository({required this.firestore});
+
+  /// جلب بيانات المستخدم من Firestore حسب رقم الهاتف
+  Future<UserModel?> getUserData(String phone) async {
+    try {
+      final docSnapshot = await firestore.collection('users').doc(phone).get();
+      if (docSnapshot.exists) {
+        final data = docSnapshot.data();
+        if (data != null) {
+          // تحويل البيانات إلى UserModel باستخدام fromJson
+          return UserModel.fromJson(data);
+        }
+      }
+      return null; // لا توجد بيانات للمستخدم
+    } catch (e) {
+      print('Error fetching user data: $e');
+      rethrow;
+    }
+  }
+}

--- a/lib/features/home/logic/cubit/home_cubit.dart
+++ b/lib/features/home/logic/cubit/home_cubit.dart
@@ -1,22 +1,71 @@
 import 'package:bloc/bloc.dart';
+import 'package:magicchat/core/helpers/shared_pref_helper.dart';
+import 'package:magicchat/features/home/data/repo/user_repo.dart';
 import 'home_state.dart';
 
 class HomeCubit extends Cubit<HomeState> {
-  HomeCubit() : super(HomeState.initial());
+  final UserRepository userRepository;
+
+  HomeCubit({required this.userRepository}) : super(const HomeState.initial());
 
   void onTabTapped(int index) {
-    if (index != state.currentIndex) {
-      final newStack = List<int>.from(state.navigationStack)..add(index);
-      emit(HomeState(currentIndex: index, navigationStack: newStack));
+    if (state is HomeLoaded) {
+      final loaded = state as HomeLoaded;
+      if (index != loaded.currentIndex) {
+        final newStack = List<int>.from(loaded.navigationStack)..add(index);
+        emit(HomeState.loaded(
+          user: loaded.user,
+          isLoggedIn: loaded.user != null,
+          currentIndex: index,
+          navigationStack: newStack,
+        ));
+      }
     }
   }
 
   Future<bool> onWillPop() async {
-    if (state.navigationStack.length > 1) {
-      final newStack = List<int>.from(state.navigationStack)..removeLast();
-      emit(HomeState(currentIndex: newStack.last, navigationStack: newStack));
-      return false;
+    if (state is HomeLoaded) {
+      final loaded = state as HomeLoaded;
+      if (loaded.navigationStack.length > 1) {
+        final newStack = List<int>.from(loaded.navigationStack)..removeLast();
+        emit(HomeState.loaded(
+          user: loaded.user,
+          isLoggedIn: loaded.user != null,
+          currentIndex: newStack.last,
+          navigationStack: newStack,
+        ));
+        return false;
+      }
     }
     return true;
+  }
+
+  Future<void> checkUserLoginStatus() async {
+    emit(const HomeState.loading());
+
+    try {
+      final phone = await SharedPrefHelper.getString('user_phone');
+
+      if (phone.isNotEmpty == true) {
+        final userData = await userRepository.getUserData(phone);
+
+        emit(HomeState.loaded(
+          user: userData,
+          isLoggedIn: userData != null,
+          currentIndex: 0,
+          navigationStack: [0],
+        ));
+      } else {
+        // مستخدم لم يسجل من قبل
+        emit(const HomeState.loaded(
+          user: null,
+          isLoggedIn: false,
+          currentIndex: 0,
+          navigationStack: [0],
+        ));
+      }
+    } catch (e) {
+      emit(HomeState.error(e.toString()));
+    }
   }
 }

--- a/lib/features/home/logic/cubit/home_state.dart
+++ b/lib/features/home/logic/cubit/home_state.dart
@@ -1,15 +1,20 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-part 'home_state.freezed.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
 
+part 'home_state.freezed.dart';
 @freezed
 class HomeState with _$HomeState {
-  const factory HomeState({
+  const factory HomeState.initial() = HomeInitial;
+
+  const factory HomeState.loading() = HomeLoading;
+
+  const factory HomeState.loaded({
+    UserModel? user,              // يمكن null لو مش مسجل دخول
+    required bool isLoggedIn,     // يوضح حالة تسجيل الدخول
     required int currentIndex,
     required List<int> navigationStack,
-  }) = _HomeState;
+  }) = HomeLoaded;
 
-  factory HomeState.initial() => const HomeState(
-        currentIndex: 0,
-        navigationStack: [0],
-      );
+  const factory HomeState.error(String message) = HomeError;
 }
+

--- a/lib/features/home/logic/cubit/home_state.freezed.dart
+++ b/lib/features/home/logic/cubit/home_state.freezed.dart
@@ -16,13 +16,61 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$HomeState {
-  int get currentIndex => throw _privateConstructorUsedError;
-  List<int> get navigationStack => throw _privateConstructorUsedError;
-
-  /// Create a copy of HomeState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $HomeStateCopyWith<HomeState> get copyWith =>
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel? user, bool isLoggedIn,
+            int currentIndex, List<int> navigationStack)
+        loaded,
+    required TResult Function(String message) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult? Function(String message)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HomeInitial value) initial,
+    required TResult Function(HomeLoading value) loading,
+    required TResult Function(HomeLoaded value) loaded,
+    required TResult Function(HomeError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HomeInitial value)? initial,
+    TResult? Function(HomeLoading value)? loading,
+    TResult? Function(HomeLoaded value)? loaded,
+    TResult? Function(HomeError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HomeInitial value)? initial,
+    TResult Function(HomeLoading value)? loading,
+    TResult Function(HomeLoaded value)? loaded,
+    TResult Function(HomeError value)? error,
+    required TResult orElse(),
+  }) =>
       throw _privateConstructorUsedError;
 }
 
@@ -30,8 +78,6 @@ mixin _$HomeState {
 abstract class $HomeStateCopyWith<$Res> {
   factory $HomeStateCopyWith(HomeState value, $Res Function(HomeState) then) =
       _$HomeStateCopyWithImpl<$Res, HomeState>;
-  @useResult
-  $Res call({int currentIndex, List<int> navigationStack});
 }
 
 /// @nodoc
@@ -46,42 +92,273 @@ class _$HomeStateCopyWithImpl<$Res, $Val extends HomeState>
 
   /// Create a copy of HomeState
   /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
+}
+
+/// @nodoc
+abstract class _$$HomeInitialImplCopyWith<$Res> {
+  factory _$$HomeInitialImplCopyWith(
+          _$HomeInitialImpl value, $Res Function(_$HomeInitialImpl) then) =
+      __$$HomeInitialImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HomeInitialImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$HomeInitialImpl>
+    implements _$$HomeInitialImplCopyWith<$Res> {
+  __$$HomeInitialImplCopyWithImpl(
+      _$HomeInitialImpl _value, $Res Function(_$HomeInitialImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HomeInitialImpl implements HomeInitial {
+  const _$HomeInitialImpl();
+
   @override
-  $Res call({
-    Object? currentIndex = null,
-    Object? navigationStack = null,
+  String toString() {
+    return 'HomeState.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$HomeInitialImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel? user, bool isLoggedIn,
+            int currentIndex, List<int> navigationStack)
+        loaded,
+    required TResult Function(String message) error,
   }) {
-    return _then(_value.copyWith(
-      currentIndex: null == currentIndex
-          ? _value.currentIndex
-          : currentIndex // ignore: cast_nullable_to_non_nullable
-              as int,
-      navigationStack: null == navigationStack
-          ? _value.navigationStack
-          : navigationStack // ignore: cast_nullable_to_non_nullable
-              as List<int>,
-    ) as $Val);
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult? Function(String message)? error,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HomeInitial value) initial,
+    required TResult Function(HomeLoading value) loading,
+    required TResult Function(HomeLoaded value) loaded,
+    required TResult Function(HomeError value) error,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HomeInitial value)? initial,
+    TResult? Function(HomeLoading value)? loading,
+    TResult? Function(HomeLoaded value)? loaded,
+    TResult? Function(HomeError value)? error,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HomeInitial value)? initial,
+    TResult Function(HomeLoading value)? loading,
+    TResult Function(HomeLoaded value)? loaded,
+    TResult Function(HomeError value)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
   }
 }
 
-/// @nodoc
-abstract class _$$HomeStateImplCopyWith<$Res>
-    implements $HomeStateCopyWith<$Res> {
-  factory _$$HomeStateImplCopyWith(
-          _$HomeStateImpl value, $Res Function(_$HomeStateImpl) then) =
-      __$$HomeStateImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({int currentIndex, List<int> navigationStack});
+abstract class HomeInitial implements HomeState {
+  const factory HomeInitial() = _$HomeInitialImpl;
 }
 
 /// @nodoc
-class __$$HomeStateImplCopyWithImpl<$Res>
-    extends _$HomeStateCopyWithImpl<$Res, _$HomeStateImpl>
-    implements _$$HomeStateImplCopyWith<$Res> {
-  __$$HomeStateImplCopyWithImpl(
-      _$HomeStateImpl _value, $Res Function(_$HomeStateImpl) _then)
+abstract class _$$HomeLoadingImplCopyWith<$Res> {
+  factory _$$HomeLoadingImplCopyWith(
+          _$HomeLoadingImpl value, $Res Function(_$HomeLoadingImpl) then) =
+      __$$HomeLoadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HomeLoadingImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$HomeLoadingImpl>
+    implements _$$HomeLoadingImplCopyWith<$Res> {
+  __$$HomeLoadingImplCopyWithImpl(
+      _$HomeLoadingImpl _value, $Res Function(_$HomeLoadingImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HomeLoadingImpl implements HomeLoading {
+  const _$HomeLoadingImpl();
+
+  @override
+  String toString() {
+    return 'HomeState.loading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$HomeLoadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel? user, bool isLoggedIn,
+            int currentIndex, List<int> navigationStack)
+        loaded,
+    required TResult Function(String message) error,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult? Function(String message)? error,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HomeInitial value) initial,
+    required TResult Function(HomeLoading value) loading,
+    required TResult Function(HomeLoaded value) loaded,
+    required TResult Function(HomeError value) error,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HomeInitial value)? initial,
+    TResult? Function(HomeLoading value)? loading,
+    TResult? Function(HomeLoaded value)? loaded,
+    TResult? Function(HomeError value)? error,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HomeInitial value)? initial,
+    TResult Function(HomeLoading value)? loading,
+    TResult Function(HomeLoaded value)? loaded,
+    TResult Function(HomeError value)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HomeLoading implements HomeState {
+  const factory HomeLoading() = _$HomeLoadingImpl;
+}
+
+/// @nodoc
+abstract class _$$HomeLoadedImplCopyWith<$Res> {
+  factory _$$HomeLoadedImplCopyWith(
+          _$HomeLoadedImpl value, $Res Function(_$HomeLoadedImpl) then) =
+      __$$HomeLoadedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call(
+      {UserModel? user,
+      bool isLoggedIn,
+      int currentIndex,
+      List<int> navigationStack});
+}
+
+/// @nodoc
+class __$$HomeLoadedImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$HomeLoadedImpl>
+    implements _$$HomeLoadedImplCopyWith<$Res> {
+  __$$HomeLoadedImplCopyWithImpl(
+      _$HomeLoadedImpl _value, $Res Function(_$HomeLoadedImpl) _then)
       : super(_value, _then);
 
   /// Create a copy of HomeState
@@ -89,10 +366,20 @@ class __$$HomeStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? user = freezed,
+    Object? isLoggedIn = null,
     Object? currentIndex = null,
     Object? navigationStack = null,
   }) {
-    return _then(_$HomeStateImpl(
+    return _then(_$HomeLoadedImpl(
+      user: freezed == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as UserModel?,
+      isLoggedIn: null == isLoggedIn
+          ? _value.isLoggedIn
+          : isLoggedIn // ignore: cast_nullable_to_non_nullable
+              as bool,
       currentIndex: null == currentIndex
           ? _value.currentIndex
           : currentIndex // ignore: cast_nullable_to_non_nullable
@@ -107,11 +394,20 @@ class __$$HomeStateImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$HomeStateImpl implements _HomeState {
-  const _$HomeStateImpl(
-      {required this.currentIndex, required final List<int> navigationStack})
+class _$HomeLoadedImpl implements HomeLoaded {
+  const _$HomeLoadedImpl(
+      {this.user,
+      required this.isLoggedIn,
+      required this.currentIndex,
+      required final List<int> navigationStack})
       : _navigationStack = navigationStack;
 
+  @override
+  final UserModel? user;
+// يمكن null لو مش مسجل دخول
+  @override
+  final bool isLoggedIn;
+// يوضح حالة تسجيل الدخول
   @override
   final int currentIndex;
   final List<int> _navigationStack;
@@ -124,14 +420,17 @@ class _$HomeStateImpl implements _HomeState {
 
   @override
   String toString() {
-    return 'HomeState(currentIndex: $currentIndex, navigationStack: $navigationStack)';
+    return 'HomeState.loaded(user: $user, isLoggedIn: $isLoggedIn, currentIndex: $currentIndex, navigationStack: $navigationStack)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$HomeStateImpl &&
+            other is _$HomeLoadedImpl &&
+            (identical(other.user, user) || other.user == user) &&
+            (identical(other.isLoggedIn, isLoggedIn) ||
+                other.isLoggedIn == isLoggedIn) &&
             (identical(other.currentIndex, currentIndex) ||
                 other.currentIndex == currentIndex) &&
             const DeepCollectionEquality()
@@ -139,7 +438,7 @@ class _$HomeStateImpl implements _HomeState {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, currentIndex,
+  int get hashCode => Object.hash(runtimeType, user, isLoggedIn, currentIndex,
       const DeepCollectionEquality().hash(_navigationStack));
 
   /// Create a copy of HomeState
@@ -147,24 +446,263 @@ class _$HomeStateImpl implements _HomeState {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$HomeStateImplCopyWith<_$HomeStateImpl> get copyWith =>
-      __$$HomeStateImplCopyWithImpl<_$HomeStateImpl>(this, _$identity);
+  _$$HomeLoadedImplCopyWith<_$HomeLoadedImpl> get copyWith =>
+      __$$HomeLoadedImplCopyWithImpl<_$HomeLoadedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel? user, bool isLoggedIn,
+            int currentIndex, List<int> navigationStack)
+        loaded,
+    required TResult Function(String message) error,
+  }) {
+    return loaded(user, isLoggedIn, currentIndex, navigationStack);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult? Function(String message)? error,
+  }) {
+    return loaded?.call(user, isLoggedIn, currentIndex, navigationStack);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(user, isLoggedIn, currentIndex, navigationStack);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HomeInitial value) initial,
+    required TResult Function(HomeLoading value) loading,
+    required TResult Function(HomeLoaded value) loaded,
+    required TResult Function(HomeError value) error,
+  }) {
+    return loaded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HomeInitial value)? initial,
+    TResult? Function(HomeLoading value)? loading,
+    TResult? Function(HomeLoaded value)? loaded,
+    TResult? Function(HomeError value)? error,
+  }) {
+    return loaded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HomeInitial value)? initial,
+    TResult Function(HomeLoading value)? loading,
+    TResult Function(HomeLoaded value)? loaded,
+    TResult Function(HomeError value)? error,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(this);
+    }
+    return orElse();
+  }
 }
 
-abstract class _HomeState implements HomeState {
-  const factory _HomeState(
-      {required final int currentIndex,
-      required final List<int> navigationStack}) = _$HomeStateImpl;
+abstract class HomeLoaded implements HomeState {
+  const factory HomeLoaded(
+      {final UserModel? user,
+      required final bool isLoggedIn,
+      required final int currentIndex,
+      required final List<int> navigationStack}) = _$HomeLoadedImpl;
 
-  @override
+  UserModel? get user; // يمكن null لو مش مسجل دخول
+  bool get isLoggedIn; // يوضح حالة تسجيل الدخول
   int get currentIndex;
-  @override
   List<int> get navigationStack;
 
   /// Create a copy of HomeState
   /// with the given fields replaced by the non-null parameter values.
-  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$HomeStateImplCopyWith<_$HomeStateImpl> get copyWith =>
+  _$$HomeLoadedImplCopyWith<_$HomeLoadedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$HomeErrorImplCopyWith<$Res> {
+  factory _$$HomeErrorImplCopyWith(
+          _$HomeErrorImpl value, $Res Function(_$HomeErrorImpl) then) =
+      __$$HomeErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$HomeErrorImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$HomeErrorImpl>
+    implements _$$HomeErrorImplCopyWith<$Res> {
+  __$$HomeErrorImplCopyWithImpl(
+      _$HomeErrorImpl _value, $Res Function(_$HomeErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$HomeErrorImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HomeErrorImpl implements HomeError {
+  const _$HomeErrorImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'HomeState.error(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HomeErrorImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HomeErrorImplCopyWith<_$HomeErrorImpl> get copyWith =>
+      __$$HomeErrorImplCopyWithImpl<_$HomeErrorImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel? user, bool isLoggedIn,
+            int currentIndex, List<int> navigationStack)
+        loaded,
+    required TResult Function(String message) error,
+  }) {
+    return error(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult? Function(String message)? error,
+  }) {
+    return error?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel? user, bool isLoggedIn, int currentIndex,
+            List<int> navigationStack)?
+        loaded,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HomeInitial value) initial,
+    required TResult Function(HomeLoading value) loading,
+    required TResult Function(HomeLoaded value) loaded,
+    required TResult Function(HomeError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HomeInitial value)? initial,
+    TResult? Function(HomeLoading value)? loading,
+    TResult? Function(HomeLoaded value)? loaded,
+    TResult? Function(HomeError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HomeInitial value)? initial,
+    TResult Function(HomeLoading value)? loading,
+    TResult Function(HomeLoaded value)? loaded,
+    TResult Function(HomeError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HomeError implements HomeState {
+  const factory HomeError(final String message) = _$HomeErrorImpl;
+
+  String get message;
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$HomeErrorImplCopyWith<_$HomeErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/features/home/ui/views/home_screen.dart
+++ b/lib/features/home/ui/views/home_screen.dart
@@ -13,40 +13,56 @@ import '../widgets/custom_bottom_nav_bar.dart';
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
-  final List<Widget> _tabs = const [
-    FriendsScreen(),
-    AiScreen(),
-    ChatbotScreen(),
-  ];
-
   @override
   Widget build(BuildContext context) {
+    final _ = context.locale;
+
     return BlocBuilder<HomeCubit, HomeState>(
       builder: (context, state) {
         final cubit = context.read<HomeCubit>();
-    
-        return WillPopScope(
-          onWillPop: cubit.onWillPop,
-          child: Scaffold(
-            appBar: AppBar(
-              title:  Text('home.app_title'.tr()),
-              actions: [
-                IconButton(
-                  icon: const Icon(Icons.settings),
-                  onPressed: () {
-                    context.pushNamed(Routes.settingsScreen);
-                  },
+
+        return state.when(
+          initial: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          loaded: (user, isLoggedIn, currentIndex, navigationStack) {
+            final tabs = [
+              FriendsScreen(isLoggedIn: isLoggedIn, user: user),
+              const AiScreen(),
+              const ChatbotScreen(),
+            ];
+            return WillPopScope(
+              onWillPop: cubit.onWillPop,
+              child: Scaffold(
+                appBar: AppBar(
+                  title: Text('home.app_title'.tr()),
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.settings),
+                      onPressed: () {
+                        context.pushNamed(
+                          Routes.settingsScreen,
+                          arguments: {
+                            'isLoggedIn': isLoggedIn,
+                            'user': user,
+                          },
+                        );
+                      },
+                    ),
+                  ],
                 ),
-              ],
-            ),
-            body: IndexedStack(
-              index: state.currentIndex,
-              children: _tabs,
-            ),
-            bottomNavigationBar: CustomBottomNavBar(
-              currentIndex: state.currentIndex,
-              onTap: cubit.onTabTapped,
-            ),
+                body: IndexedStack(
+                  index: currentIndex,
+                  children: tabs,
+                ),
+                bottomNavigationBar: CustomBottomNavBar(
+                  currentIndex: currentIndex,
+                  onTap: cubit.onTabTapped,
+                ),
+              ),
+            );
+          },
+          error: (message) => Scaffold(
+            body: Center(child: Text('Error: $message')),
           ),
         );
       },

--- a/lib/features/settings/ui/views/settings_screen.dart
+++ b/lib/features/settings/ui/views/settings_screen.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:magicchat/core/helpers/extensions.dart';
+import 'package:magicchat/core/routes/routes.dart';
+import 'package:magicchat/features/auth/logic/cubit/auth_cubit.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
 import 'package:magicchat/features/settings/logic/cubit/settings_cubit.dart';
 import 'package:magicchat/features/settings/logic/cubit/settings_state.dart';
 import 'package:magicchat/features/settings/ui/widgets/language_setting_tile.dart';
@@ -9,18 +13,26 @@ import 'package:magicchat/features/settings/ui/widgets/settings_group.dart';
 import 'package:magicchat/features/settings/ui/widgets/theme_setting_tile.dart';
 
 class SettingsScreen extends StatefulWidget {
-  const SettingsScreen({super.key});
+  final bool isLoggedIn;
+  final UserModel? user;
+
+  const SettingsScreen({
+    super.key,
+    required this.isLoggedIn,
+    required this.user,
+  });
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  bool isLoggedIn = true; // Replace with actual login check later
+  late final bool isLoggedIn;
 
   @override
   void initState() {
     super.initState();
+    isLoggedIn = widget.isLoggedIn;
     context.read<SettingsCubit>().loadSettings();
   }
 
@@ -45,7 +57,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             return ListView(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
               children: [
-                ProfileSection(isLoggedIn: isLoggedIn),
+                ProfileSection(isLoggedIn: isLoggedIn, user: widget.user),
                 const SizedBox(height: 30),
                 SettingsGroup(
                   title: 'settings.general'.tr(),
@@ -62,7 +74,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         leading: const Icon(Icons.logout),
                         title: Text('settings.logout'.tr()),
                         onTap: () {
-                          // handle logout
+                          context.read<AuthCubit>().logout().then((_) {
+                            context.pushReplacementNamed(
+                              Routes.homeScreen,
+                            );
+                          });
                         },
                       ),
                     ],

--- a/lib/features/settings/ui/widgets/profile_section.dart
+++ b/lib/features/settings/ui/widgets/profile_section.dart
@@ -1,36 +1,52 @@
 import 'package:flutter/material.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:magicchat/features/home/data/model/user_model.dart';
 
 class ProfileSection extends StatelessWidget {
   final bool isLoggedIn;
-  const ProfileSection({super.key, required this.isLoggedIn});
+  final UserModel? user;
+
+  const ProfileSection({
+    super.key,
+    required this.isLoggedIn,
+    this.user,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final defaultImage = 'https://cdn-icons-png.flaticon.com/512/149/149071.png';
+
     return Column(
       children: [
         CircleAvatar(
           radius: 40,
           backgroundColor: Theme.of(context).colorScheme.primary,
-           backgroundImage: isLoggedIn
-              ? NetworkImage('https://cdn-icons-png.flaticon.com/512/149/149071.png')
-              : NetworkImage('https://cdn-icons-png.flaticon.com/512/149/149071.png'),
+          backgroundImage: NetworkImage(
+            isLoggedIn && user?.imageUrl != null && user!.imageUrl!.isNotEmpty
+                ? user!.imageUrl!
+                : defaultImage,
+          ),
         ),
         const SizedBox(height: 12),
         Text(
-          isLoggedIn ? 'Sami Al-Madani' : 'Guest',
+          isLoggedIn ? user?.username ?? 'User' : 'Guest',
           style: Theme.of(context).textTheme.titleMedium,
         ),
         const SizedBox(height: 4),
         if (isLoggedIn)
-          Text('+123456789', style: Theme.of(context).textTheme.bodySmall),
+          Text(
+            user?.phone ?? '',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
         const SizedBox(height: 12),
         OutlinedButton.icon(
           onPressed: () {
             // navigate to login or profile
           },
           icon: Icon(isLoggedIn ? Icons.person : Icons.login),
-          label: Text(isLoggedIn ? 'settings.profile'.tr() : 'settings.login'.tr()),
+          label: Text(
+            isLoggedIn ? 'settings.profile'.tr() : 'settings.login'.tr(),
+          ),
         ),
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -11,6 +12,7 @@ import 'package:magicchat/magic_chat_app.dart';
 import 'core/routes/app_router.dart' hide getIt;
 
 void main() async {
+
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   await EasyLocalization.ensureInitialized();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1050,6 +1050,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
+  intl_phone_field:
+    dependency: "direct main"
+    description:
+      name: intl_phone_field
+      sha256: "73819d3dfcb68d2c85663606f6842597c3ddf6688ac777f051b17814fe767bbf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   io:
     dependency: transitive
     description:
@@ -1314,6 +1322,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  pin_code_fields:
+    dependency: "direct main"
+    description:
+      name: pin_code_fields
+      sha256: "4c0db7fbc889e622e7c71ea54b9ee624bb70c7365b532abea0271b17ea75b729"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.1"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project created with custom scaffold script.
 publish_to: 'none' # Remove this line if publishing to pub.dev
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -80,6 +80,8 @@ dependencies:
   dropdown_button2: ^2.3.9
   audioplayers: ^6.5.0
   url_launcher: ^6.3.1
+  intl_phone_field: ^3.2.0
+  pin_code_fields: ^8.0.1
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
…and UsernameSetupScreen

Implement fake OTP authentication logic using AuthCubit and AuthRepository

Add UserModel with isLoggedIn field to track user login state (temporary structure inside home feature)

Handle case where a logged-out user prevents re-registering with an existing phone number

Store current user phone number locally using SharedPreferences

NOTE: UserModel currently lives under home feature and needs refactoring in future stages